### PR TITLE
x11 forwarding should be configurable like tcp and agent forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This cookbook provides secure ssh-client and ssh-server configurations.
 * `['ssh']['remote_hosts']` - one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!
 * `['ssh']['allow_tcp_forwarding']` - `false` to disable TCP Forwarding. Set to `true` to allow TCP Forwarding
 * `['ssh']['allow_agent_forwarding']` - `false` to disable Agent Forwarding. Set to `true` to allow Agent Forwarding
+* `['ssh']['allow_x11_forwarding']` - `false` to disable X11 Forwarding. Set to `true` to allow X11 Forwarding
 * `['ssh']['use_pam']` - `false` to disable pam authentication
 * `['ssh']['print_motd']` - `false` to disable printing of the MOTD
 * `['ssh']['print_last_log']` - `false` to disable display of last login information

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,6 +58,7 @@ default['ssh']['remote_hosts']            = []     # ssh
 default['ssh']['allow_root_with_key']     = false   # sshd
 default['ssh']['allow_tcp_forwarding']    = false   # sshd
 default['ssh']['allow_agent_forwarding']  = false   # sshd
+default['ssh']['allow_x11_forwarding']    = false   # sshd
 default['ssh']['use_pam']                 = false   # sshd
 default['ssh']['deny_users']              = []      # sshd
 default['ssh']['allow_users']             = []      # sshd

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -174,7 +174,11 @@ AllowAgentForwarding no
 GatewayPorts no
 
 # Disable X11 forwarding, since local X11 display could be accessed through forwarded connection.
+<% if @node['ssh']['allow_x11_forwarding'] %>
+X11Forwarding yes
+<% else %>
 X11Forwarding no
+<% end %>
 X11UseLocalhost yes
 
 

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -156,19 +156,11 @@ PermitTunnel no
 
 # Disable forwarding tcp connections.
 # no real advantage without denied shell access
-<% if @node['ssh']['allow_tcp_forwarding'] %>
-AllowTcpForwarding yes
-<% else %>
-AllowTcpForwarding no
-<% end %>
+AllowTcpForwarding  <%= ((@node['ssh']['allow_tcp_forwarding']) ? 'yes' : 'no' ) %>
 
 # Disable agent formwarding, since local agent could be accessed through forwarded connection.
 # no real advantage without denied shell access
-<% if @node['ssh']['allow_agent_forwarding'] %>
-AllowAgentForwarding yes
-<% else %>
-AllowAgentForwarding no
-<% end %>
+AllowAgentForwarding  <%= ((@node['ssh']['allow_agent_forwarding']) ? 'yes' : 'no' ) %>
 
 # Do not allow remote port forwardings to bind to non-loopback addresses.
 GatewayPorts no

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -174,11 +174,7 @@ AllowAgentForwarding no
 GatewayPorts no
 
 # Disable X11 forwarding, since local X11 display could be accessed through forwarded connection.
-<% if @node['ssh']['allow_x11_forwarding'] %>
-X11Forwarding yes
-<% else %>
-X11Forwarding no
-<% end %>
+X11Forwarding  <%= ((@node['ssh']['allow_x11_forwarding']) ? 'yes' : 'no' ) %>
 X11UseLocalhost yes
 
 


### PR DESCRIPTION
Seems that the concern is similar for tcp and agent, and yet they are configurable.

If I am the only user on my server, and I'm choosing to trust it for agent forwarding, x11 forwarding should not compromise my local system to any greater degree, correct?