### PR TITLE
Apply PasswordAuthentication attribute to SSH

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,7 +66,7 @@ default['ssh']['deny_groups']             = []      # sshd
 default['ssh']['allow_groups']            = []      # sshd
 default['ssh']['print_motd']              = false   # sshd
 default['ssh']['print_last_log']          = false   # sshd
-default['ssh']['password_authentication'] = false    # sshd
+default['ssh']['password_authentication'] = false    # sshd + ssh
 # set this to nil to let us use the default OpenSSH in case it's not set by the user
 default['ssh']['use_dns']                 = nil     # sshd
 # set this to nil to let us detect the attribute based on the node platform

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,10 +66,11 @@ default['ssh']['deny_groups']             = []      # sshd
 default['ssh']['allow_groups']            = []      # sshd
 default['ssh']['print_motd']              = false   # sshd
 default['ssh']['print_last_log']          = false   # sshd
-default['ssh']['password_authentication'] = false    # sshd + ssh
 # set this to nil to let us use the default OpenSSH in case it's not set by the user
 default['ssh']['use_dns']                 = nil     # sshd
 # set this to nil to let us detect the attribute based on the node platform
 default['ssh']['use_privilege_separation'] = nil
 default['ssh']['max_auth_tries']           = 2      # sshd
 default['ssh']['max_sessions']             = 10     # sshd
+default['ssh']['client']['password_authentication'] = false   # ssh
+default['ssh']['server']['password_authentication'] = false   # sshd

--- a/templates/default/openssh.conf.erb
+++ b/templates/default/openssh.conf.erb
@@ -88,7 +88,7 @@ RhostsRSAAuthentication no
 RSAAuthentication yes
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
-PasswordAuthentication no
+PasswordAuthentication <%= ((@node['ssh']['password_authentication']) ? "yes" : "no" ) %>
 
 # Only use GSSAPIAuthentication if implemented on the network.
 GSSAPIAuthentication no

--- a/templates/default/openssh.conf.erb
+++ b/templates/default/openssh.conf.erb
@@ -88,7 +88,7 @@ RhostsRSAAuthentication no
 RSAAuthentication yes
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
-PasswordAuthentication <%= ((@node['ssh']['password_authentication']) ? "yes" : "no" ) %>
+PasswordAuthentication <%= ((@node['ssh']['client']['password_authentication']) ? "yes" : "no" ) %>
 
 # Only use GSSAPIAuthentication if implemented on the network.
 GSSAPIAuthentication no

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -104,7 +104,8 @@ HostbasedAuthentication no
 # Enable PAM to enforce system wide rules
 UsePAM <%= ((@node['ssh']['use_pam']) ? "yes" : "no" ) %>
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
-PasswordAuthentication <%= ((@node['ssh']['password_authentication']) ? "yes" : "no" ) %>
+<% passsword_auth = @node['ssh']['server']['password_authentication'] || !!@node['ssh']['password_authentication'] -%>
+PasswordAuthentication <%= (passsword_auth ? "yes" : "no" ) %>
 PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 


### PR DESCRIPTION
Applying the PasswordAuthentication attribute from #102 to openssh.conf.

Not sure if its best to use the same attribute, or have separate attributes for SSH and SSHD?