### PR TITLE
Disable experimental client roaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This cookbook provides secure ssh-client and ssh-server configurations.
 * `['ssh'][{'client', 'server'}]['cbc_required']` - true if CBC for ciphers is required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure ciphers enabled. CBC is a weak alternative. Anything weaker should be avoided and is thus not available.
 * `['ssh'][{'client', 'server'}]['weak_hmac']` - true if weaker HMAC mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure HMACs enabled.
 * `['ssh'][{'client', 'server'}]['weak_kex']` - true if weaker Key-Exchange (KEX) mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.
+* `['ssh']['client']['roaming']` - enable experimental client roaming. This is known to cause potential issues with secrets being disclosed to malicious servers and defaults to being disabled.
 * `['ssh']['allow_root_with_key']` - `false` to disable root login altogether. Set to `true` to allow root to login via key-based mechanism.
 * `['ssh']['ports']` - ports to which ssh-server should listen to and ssh-client should connect to
 * `['ssh']['listen_to']` - one or more ip addresses, to which ssh-server should listen to. Default is empty, but should be configured for security reasons!

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,3 +74,5 @@ default['ssh']['max_auth_tries']           = 2      # sshd
 default['ssh']['max_sessions']             = 10     # sshd
 default['ssh']['client']['password_authentication'] = false   # ssh
 default['ssh']['server']['password_authentication'] = false   # sshd
+# http://undeadly.org/cgi?action=article&sid=20160114142733
+default['ssh']['client']['roaming']        = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,4 +26,3 @@ version          "1.1.0"
 recipe 'ssh-hardening::default', 'installs and configures ssh client and server'
 recipe 'ssh-hardening::client', 'install and apply security hardening for ssh client'
 recipe 'ssh-hardening::server', 'install and apply security hardening for ssh server'
-

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -64,6 +64,7 @@ template '/etc/ssh/ssh_config' do
   variables(
     mac: SshMac.get_macs(node, node['ssh']['client']['weak_hmac']),
     kex: SshKex.get_kexs(node, node['ssh']['client']['weak_kex']),
-    cipher: SshCipher.get_ciphers(node, node['ssh']['client']['cbc_required'])
+    cipher: SshCipher.get_ciphers(node, node['ssh']['client']['cbc_required']),
+    roaming: node['ssh']['client']['roaming']
   )
 end

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -61,6 +61,11 @@ describe 'ssh-hardening::client' do
       with_content(/Ciphers [^#]*-cbc\b/)
   end
 
+  it 'disables client roaming' do
+    expect(chef_run).to render_file('/etc/ssh/ssh_config').
+      with_content(/UseRoaming no/)
+  end
+
   it 'enables ctr ciphers' do
     expect(chef_run).to render_file('/etc/ssh/ssh_config').
       with_content(/Ciphers [^#]*\baes128-ctr\b/).

--- a/templates/default/openssh.conf.erb
+++ b/templates/default/openssh.conf.erb
@@ -3,9 +3,9 @@
 <% end %>
 #---
 
-# This is the ssh client system-wide configuration file. 
+# This is the ssh client system-wide configuration file.
 # See ssh_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.
-# 
+#
 # Created for OpenSSH v5.9
 
 # Basic configuration
@@ -49,15 +49,15 @@ StrictHostKeyChecking ask
 # CBC: is true if you want to connect with OpenSSL-base libraries
 # eg ruby Net::SSH::Transport::CipherFactory requires cbc-versions of the given openssh ciphers to work
 # -- see: (http://net-ssh.github.com/net-ssh/classes/Net/SSH/Transport/CipherFactory.html)
-# 
+#
 <% if @cipher %>
 Ciphers <%= @cipher %>
 <% end %>
 
 # **Hash algorithms** -- Make sure not to use SHA1 for hashing, unless it is really necessary.
-# Weak HMAC is sometimes required if older package versions are used 
+# Weak HMAC is sometimes required if older package versions are used
 # eg Ruby's Net::SSH at around 2.2.* doesn't support sha2 for hmac, so this will have to be set true in this case.
-# 
+#
 <% if @mac %>
 MACs <%= @mac %>
 <% end %>
@@ -68,7 +68,7 @@ MACs <%= @mac %>
 # **Key Exchange Algorithms** -- Make sure not to use SHA1 for kex, unless it is really necessary
 # Weak kex is sometimes required if older package versions are used
 # eg ruby's Net::SSH at around 2.2.* doesn't support sha2 for kex, so this will have to be set true in this case.
-# 
+#
 <% if @kex %>
 KexAlgorithms <%= @kex %>
 <% end %>
@@ -109,3 +109,6 @@ Compression yes
 
 #EscapeChar ~
 #VisualHostKey yes
+
+# http://undeadly.org/cgi?action=article&sid=20160114142733
+UseRoaming <%= @roaming ? 'yes' : 'no' %>


### PR DESCRIPTION
Disable the experimental client roaming feature to mitigate [this vulnerability](http://undeadly.org/cgi?action=article&sid=20160114142733)