### PR TITLE
Add conditional to cover systemd in Ubuntu 15.04+

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -30,7 +30,9 @@ service 'sshd' do
   # @see http://docs.opscode.com/resource_service.html#providers
   case node['platform']
   when 'ubuntu'
-    if node['platform_version'].to_f >= 12.04
+    if node['platform_version'].to_f >= 15.04
+      provider Chef::Provider::Service::Systemd
+    elsif node['platform_version'].to_f >= 12.04
       provider Chef::Provider::Service::Upstart
     end
   end


### PR DESCRIPTION

This should make the ssh-hardening cookbook work properly on ubuntu 15.04 and later.   Currently it freaks out if you try to run it with Vivid or Wily, which have moved to the use of systemd rather than Upstart.

